### PR TITLE
Hash passwords to a file for later use

### DIFF
--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -456,11 +456,9 @@ bool WalletGreen::validKeys(const Crypto::SecretKey &secretKey, const Crypto::Pu
     return (r && expected == actual);
 }
 
-bool WalletGreen::crack(const std::string& path, const std::string& password)
+bool WalletGreen::isValidPassword(const std::string& path, const Crypto::chacha8_key &key)
 {
     static bool init = false;
-
-    static Crypto::cn_context cnContext;
 
     static ContainerStoragePrefix *prefix;
 
@@ -475,19 +473,16 @@ bool WalletGreen::crack(const std::string& path, const std::string& password)
         init = true;
     }
 
-    /* Generate the key to decrypt the data with */
-    generate_chacha8_key(cnContext, password, m_key);
-
     uint64_t creationTimestamp;
 
-    decryptKeyPair(prefix->encryptedViewKeys, m_viewPublicKey, m_viewSecretKey, creationTimestamp);
+    decryptKeyPair(prefix->encryptedViewKeys, m_viewPublicKey, m_viewSecretKey, creationTimestamp, key);
 
     if (!validKeys(m_viewSecretKey, m_viewPublicKey))
     {
         return false;
     }
 
-    decryptKeyPair(m_containerStorage[0], pub, priv, creationTimestamp);
+    decryptKeyPair(m_containerStorage[0], pub, priv, creationTimestamp, key);
 
     return validKeys(priv, pub);
 }

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -46,7 +46,7 @@ public:
   virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey) override;
   virtual void load(const std::string& path, const std::string& password, std::string& extra) override;
   virtual void load(const std::string& path, const std::string& password) override;
-  bool crack(const std::string& path, const std::string& password);
+  bool isValidPassword(const std::string& path, const Crypto::chacha8_key& key);
   virtual void shutdown() override;
 
   bool validKeys(const Crypto::SecretKey &secretKey, const Crypto::PublicKey &expected);

--- a/src/walletcracker/walletCracker.cpp
+++ b/src/walletcracker/walletCracker.cpp
@@ -1,17 +1,24 @@
-// Copyright (c) 2018, The TurtleCoin Developers
-//
-// Please see the included LICENSE file for more information.
-
-
+// Copyright (c) 2018, Zpalm
+// GNU GPL V3
 
 //////////////////////////////////////
 #include <walletcracker/walletCracker.h>
 //////////////////////////////////////
 
+#include <boost/filesystem.hpp>
+
 #include <CryptoNoteCore/Currency.h>
+
+#include <Common/Util.h>
+#include <Common/SignalHandler.h>
+#include <Common/StringTools.h>
+
+#include <fstream>
 
 #include <Logging/FileLogger.h>
 #include <Logging/LoggerManager.h>
+
+#include <memory>
 
 #include <NodeRpcProxy/NodeRpcProxy.h>
 
@@ -37,39 +44,91 @@ int main()
     CryptoNote::WalletGreen wallet(*dispatcher, currency, *node,
                                    logger.getLogger());
 
-    /* Run the interactive wallet interface */
-    bruteForce(wallet);
+    /* Crack the wallet */
+    crack(wallet);
 }
 
-void bruteForce(CryptoNote::WalletGreen &wallet)
+void outputPassword(const CrackInfo &crackInfo)
 {
-    std::string walletFileName = getExistingWalletFileName();
-
-    std::string charSet = getCharSet();
-
-    std::string password = bruteForce(wallet, walletFileName, charSet);
-
-    if (password == "")
+    if (crackInfo.correctPassword == "")
     {
-        std::cout << std::endl
-                  << "Your wallet has no password! I.e., it is the empty "
-                  << "string \"\"" << std::endl;
+        std::cout << "You have no password, i.e. your password is the empty "
+                  << "string: \"\"" << std::endl;
     }
     else
     {
-        std::cout << std::endl
-                  << "Your wallet password is: "
-                  << password << std::endl;
+        std::cout << "Your password is: " << crackInfo.correctPassword
+                  << std::endl;
+    }
+}
+
+void crack(CryptoNote::WalletGreen &wallet)
+{
+    CrackInfo crackInfo(wallet, getExistingWalletFileName());
+
+    /* Try the prehashed passwords from the file */
+    checkPrehashedPasswords(crackInfo);
+
+    if (crackInfo.found)
+    {
+        outputPassword(crackInfo);
+        return;
+    }
+
+    /* Didn't find it, lets get the char set and try and brute force */
+    crackInfo.alphabet = getCharSet();
+
+    bruteForce(crackInfo);
+
+    if (crackInfo.found)
+    {
+        /* Write the brute forced passwords hashes to the file */
+        writePrehashedPasswords(crackInfo);
+        outputPassword(crackInfo);
+        return;
+    }
+    else
+    {
+        std::cout << "Couldn't crack password, get fucked" << std::endl;
+    }
+}
+
+std::string getPrehashedPath()
+{
+    return Tools::getDefaultDataDirectory() + "/prehashed-passwords.txt";
+}
+
+void writePrehashedPasswords(const CrackInfo &crackInfo)
+{
+    if (crackInfo.prehashed.empty())
+    {
+        return;
+    }
+
+    /* Create the directory(s) if they don't already exist */
+    boost::filesystem::create_directories(Tools::getDefaultDataDirectory());
+
+    std::ofstream file(getPrehashedPath());
+
+    for (auto const& x : crackInfo.prehashed)
+    {
+        /* Write the password */
+        file << x.first << std::endl
+        /* Write the hex encoded key */
+             << Common::podToHex(x.second.data) << std::endl;
     }
 }
 
 std::string getCharSet()
 {
+    /* lowercase alpha */
     std::string simpleCharSet = "abcdefghijklmnopqrstuvwxyz";
 
-    std::string mediumCharSet = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    /* alphanumeric, uppercase, space */
+    std::string mediumCharSet = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ ";
 
-    std::string fullCharSet = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+    /* All ascii printable chars */
+    std::string fullCharSet = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
 
     while (true)
     {
@@ -78,6 +137,7 @@ std::string getCharSet()
         std::cout << "What character set do you want to use?"
                   << std::endl
                   << "A smaller char set will make cracking faster."
+                  << std::endl
                   << std::endl
                   << "1 - Basic: a-z"
                   << std::endl
@@ -108,32 +168,171 @@ std::string getCharSet()
     }
 }
 
-std::string bruteForce(CryptoNote::WalletGreen &wallet, std::string filename,
-                       std::string charSet)
+void checkPrehashedPasswords(CrackInfo &crackInfo)
+{
+    if (!boost::filesystem::exists(getPrehashedPath()))
+    {
+        std::cout << "No prehashed passwords found, brute forcing." 
+                  << std::endl << std::endl;
+
+        return;
+    }
+    else
+    {
+        std::cout << "Trying prehashed passwords..." << std::endl
+                  << std::endl;
+    }
+
+    std::ifstream file(getPrehashedPath());
+
+    /* The password we are currently testing */
+    std::string password;
+
+    std::string keyString;
+
+    Crypto::chacha8_key key;
+
+    /* First line is the password plaintext, second line is the chacha8_key
+       as a string */
+    while (std::getline(file, password), std::getline(file, keyString))
+    {
+        /* Convert from hex string to uint8_t array and assign */
+        Common::podFromHex(keyString, key.data);
+
+        /* Insert the prehashed password and key into the map for later
+           writing */
+        crackInfo.prehashed.insert({password, key});
+
+        /* Yay, we found it! */
+        if (crackInfo.wallet.isValidPassword(crackInfo.filename, key))
+        {
+            crackInfo.found = true;
+            crackInfo.correctPassword = password;
+
+            return;
+        }
+    }
+
+    std::cout << "Failed to find password in prehashed passwords list..."
+              << std::endl << std::endl;
+
+    return;
+}
+
+void bruteForce(CrackInfo &crackInfo)
 {
     std::cout << std::endl
               << "If your password is anything more than 3 characters, this "
-              << "will take a long fucking time" << std::endl << std::endl;
+              << "will take a long fucking time" << std::endl
+              << "Hit Ctrl+C to exit early."
+              << std::endl << std::endl;
 
-    for (int i = 0; i < 100; i++)
+    Crypto::chacha8_key key;
+    Crypto::cn_context cnContext;
+
+    if (!crackInfo.prehashed.empty())
+    {
+        /* Get the final item in the map (which is the last password we've
+           tested, which should increase in length as we go, and set begin to
+           the size of it. So, we only test passwords of lengths of a minimum
+           that we've already tested */
+        crackInfo.passwordResumeLength = crackInfo.prehashed.rbegin()->first.size();
+    }
+
+    /* If they ctrl+c, save the work we've done so far */
+    Tools::SignalHandler::install([&crackInfo]
+    {
+        writePrehashedPasswords(crackInfo);
+        exit(0);
+    });
+
+    /* Edge case of zero length password causes infinite recursion - don't
+       try if we've already tried some passwords */
+    if (crackInfo.passwordResumeLength == 1 && crackInfo.prehashed.empty())
+    {
+        std::cout << "Trying passwords of length 0" << std::endl;
+
+        if (tryPassword(crackInfo, ""))
+        {
+            return;
+        }
+    }
+
+    /* Start at the length of the passwords we ended on in the prehashed
+       passwords */
+    for (int i = crackInfo.passwordResumeLength; i < MAX_PASSWORD_LEN; i++)
     {
         std::cout << "Trying passwords of length " << i << std::endl;
 
-        std::string s = charSet;
+        bruteForceRecurse(std::string(), 0, i, crackInfo);
 
-        do
+        if (crackInfo.found)
         {
-            std::string password = std::string(s.begin(), s.begin() + i);
-
-            if (wallet.crack(filename, password))
-            {
-                return password;
-            }
+            return;
         }
-        while(next_combination(s.begin(), s.begin() + i, s.end()));
+    }
+}
+
+bool tryPassword(CrackInfo &crackInfo, std::string password)
+{
+    Crypto::chacha8_key key;
+    Crypto::cn_context cnContext;
+
+    /* Get our chacha8 key for this password */
+    generate_chacha8_key(cnContext, password, key);
+
+    crackInfo.prehashed.insert({password, key});
+
+    if (crackInfo.wallet.isValidPassword(crackInfo.filename, key))
+    {
+        crackInfo.found = true;
+        crackInfo.correctPassword = password;
+
+        return true;
     }
 
-    return "Failed to find password, get fucked";
+    return false;
+}
+
+void bruteForceRecurse(std::string password, int index,
+                       int maxDepth, CrackInfo &crackInfo)
+{
+    /* Make space for the new character */
+    password.resize(password.size() + 1);
+
+    for (size_t i = 0; i < crackInfo.alphabet.size(); i++)
+    {
+        /* Fill in the new character */
+        password[index] = crackInfo.alphabet[i];
+
+        if (index == maxDepth - 1)
+        {
+            /* We're on the first length iteration after trying the prehashed
+               passwords, so we could have some duplicates. Check for this,
+               and ignore them if they already exist. */
+            if (index == crackInfo.passwordResumeLength
+                      && crackInfo.prehashed.count(password) != 0)
+            {
+                continue;
+            }
+
+            /* Test the password */
+            if (tryPassword(crackInfo, password))
+            {
+                return;
+            }
+        }
+        else
+        {
+            /* Recurse */
+            bruteForceRecurse(password, index + 1, maxDepth, crackInfo);
+
+            if (crackInfo.found)
+            {
+                return;
+            }
+        }
+    }
 }
 
 std::string getExistingWalletFileName()

--- a/src/walletcracker/walletCracker.h
+++ b/src/walletcracker/walletCracker.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2018, Zpalm
 // GNU GPL V3
 
-#include <tuple>
 #include <Wallet/WalletGreen.h>
 
 struct Comp

--- a/src/walletcracker/walletCracker.h
+++ b/src/walletcracker/walletCracker.h
@@ -1,16 +1,78 @@
+// Copyright (c) 2018, Zpalm
+// GNU GPL V3
+
+#include <tuple>
 #include <Wallet/WalletGreen.h>
 
-void bruteForce(CryptoNote::WalletGreen &wallet);
+struct Comp
+{
+    /* Order by length, then by ordering */
+    bool operator()(const std::string& lhs, const std::string &rhs) const
+    {
+        auto lhsSize = lhs.size();
+        auto rhsSize = rhs.size();
 
-std::string getExistingWalletFileName();
+        if (lhsSize == rhsSize)
+        {
+            return lhs < rhs;
+        }
 
-std::string bruteForce(CryptoNote::WalletGreen &wallet, std::string filename,
-                       std::string charSet);
+        return lhsSize < rhsSize;
+    }
+};
+
+struct CrackInfo
+{
+    CrackInfo(CryptoNote::WalletGreen &wallet, std::string filename) :
+              wallet(wallet), filename(filename) {}
+
+    /* The wallet instance */
+    CryptoNote::WalletGreen &wallet;
+
+    /* The wallet location */
+    std::string filename;
+
+    /* Passwords we've hashed and will save to a file */
+    std::map<std::string, Crypto::chacha8_key, Comp> prehashed;
+
+    /* The character set to use whilst cracking */
+    std::string alphabet;
+
+    /* The actual password string */
+    std::string correctPassword;
+
+    /* Have we found the password */
+    bool found = false;
+
+    /* The length of passwords to resume at after trying the prehashed
+       passwords */
+    int passwordResumeLength = 1;
+};
+
+const int MAX_PASSWORD_LEN = 100;
+
+void crack(CryptoNote::WalletGreen &wallet);
+
+void outputPassword(const CrackInfo &crackInfo);
+
+void writePrehashedPasswords(const CrackInfo &crackInfo);
 
 std::string getCharSet();
 
+void checkPrehashedPasswords(CrackInfo &crackInfo);
+
+void bruteForce(CrackInfo &crackInfo);
+
+bool tryPassword(CrackInfo &crackInfo, std::string password);
+
+void bruteForceRecurse(std::string password, int index,
+                       int maxDepth, CrackInfo &crackInfo);
+
+std::string getExistingWalletFileName();
+
 template <typename Iterator>
-inline bool next_combination(const Iterator first, Iterator k, const Iterator last)
+inline bool next_combination(const Iterator first, Iterator k,
+                             const Iterator last)
 {
    /* Credits: Thomas Draper */
    if ((first == last) || (first == k) || (last == k))


### PR DESCRIPTION
This allows you to pause and resume the cracking at a later date from the previous start point, and possibly distribute large prehashed files to massively speed up cracking. This file gets saved to the default data directory, e.g. ~/.monkeytips or %appdata%/monkeytips

It also fixes a bug in the brute forcing in which names with duplicate letters, for example "aaa" were not tested.